### PR TITLE
AUTO: auto exclude test example_functional

### DIFF
--- a/external/functional-test/playlist.xml
+++ b/external/functional-test/playlist.xml
@@ -46,6 +46,9 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/5132</comment>
 				<platform>ppc64le_linux</platform>
 			</disable>
+			<disable>
+				<comment>https://github.com/adoptium/aqa-tests/issues/4746#issuecomment-2273782103</comment>
+			</disable>
 		</disables>
 		<command> $(TEST_ROOT)$(D)external$(D)external.sh --run --tag "${DOCKERIMAGE_TAG}" --version ${JDK_VERSION} --impl ${JDK_IMPL} --dir functional-test --testtarget _testExample --reportdst $(REPORTDIR) --docker_args "$(EXTRA_DOCKER_ARGS)"; \
 		$(TEST_STATUS); \


### PR DESCRIPTION
- related: https://github.com/adoptium/aqa-tests/issues/4746#issuecomment-2273782103

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed

## Summary by Sourcery

Tests:
- Disable the `example_functional` test on ppc64le.